### PR TITLE
Upgrade missinglink-core to 0.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ lazy val `sbt-missinglink` = project
   .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.spotify" % "missinglink-core" % "0.1.5"
+      "com.spotify" % "missinglink-core" % "0.2.0",
+      "com.google.guava" % "guava" % "18.0",
     ),
 
     // configuration fro scripted

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,7 @@
-libraryDependencies += "com.spotify" % "missinglink-core" % "0.1.5"
+libraryDependencies ++= Seq(
+  "com.spotify" % "missinglink-core" % "0.2.0",
+  "com.google.guava" % "guava" % "18.0"
+)
 
 unmanagedSourceDirectories in Compile +=
   baseDirectory.value.getParentFile / "src/main/scala"


### PR DESCRIPTION
In [0.2.0][0] guava is removed from missinglink-core, to reduce the
amount of transitive dependencies for users like sbt-missinglink.

[0]: https://github.com/spotify/missinglink/releases/tag/v0.2.0