### PR TITLE
Exclude certain dependencies from the analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ missinglinkIgnoreSourcePackages += IgnoredPackage("com.example")
 
 By default, all subpackages of the specified package are also ignored, but this can be disabled by the `ignoreSubpackages` field: `IgnoredPackage("test", ignoreSubpackages = false)`.
 
-### Unsupported features
+### Excluding some dependencies from the analysis
 
-At the moment, compared to the upstream `missinglink` project, this sbt plugin
-does not support the following features:
+You can exclude certain dependencies using `moduleFilter`: 
 
-* Excluding some dependencies from the analysis
+```
+missinglinkExcludedDependencies += moduleFilter(organization = "com.google.guava")
+missinglinkExcludedDependencies += moduleFilter(organization = "ch.qos.logback", name = "logback-core")
+```
 
 ## More information
 

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -44,7 +44,6 @@ object MissingLinkPlugin extends AutoPlugin {
           "of the conflict is in one of the specified packages."
       )
 
-
     val missinglinkExcludedDependencies =
       settingKey[Seq[ModuleFilter]]("Dependencies that are excluded from analysis")
   }
@@ -310,6 +309,6 @@ object MissingLinkPlugin extends AutoPlugin {
     }
   }
 
-  final case class ModuleArtifact(artifact: Artifact, module: Option[ModuleID])
+  private final case class ModuleArtifact(artifact: Artifact, module: Option[ModuleID])
 
 }

--- a/src/sbt-test/missinglink/exclude-problematic-dependency/build.sbt
+++ b/src/sbt-test/missinglink/exclude-problematic-dependency/build.sbt
@@ -3,7 +3,7 @@ inThisBuild(Def.settings(
   scalaVersion := "2.12.8",
 ))
 
-lazy val `has-problematic-dependency` = project
+lazy val `exclude-problematic-dependency` = project
   .in(file("."))
   .settings(
     libraryDependencies ++= Seq(

--- a/src/sbt-test/missinglink/exclude-problematic-dependency/build.sbt
+++ b/src/sbt-test/missinglink/exclude-problematic-dependency/build.sbt
@@ -1,0 +1,18 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `has-problematic-dependency` = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+      "com.google.guava" % "guava" % "18.0" % Runtime,
+    ),
+
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    missinglinkExcludedDependencies += moduleFilter(organization = "com.google.guava")
+  )

--- a/src/sbt-test/missinglink/exclude-problematic-dependency/project/plugins.sbt
+++ b/src/sbt-test/missinglink/exclude-problematic-dependency/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/exclude-problematic-dependency/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/exclude-problematic-dependency/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+    BAR
+}

--- a/src/sbt-test/missinglink/exclude-problematic-dependency/src/main/scala/test/UsesProblematicDependency.scala
+++ b/src/sbt-test/missinglink/exclude-problematic-dependency/src/main/scala/test/UsesProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/exclude-problematic-dependency/test
+++ b/src/sbt-test/missinglink/exclude-problematic-dependency/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> missinglinkCheck


### PR DESCRIPTION
This PR partially covers https://github.com/scalacenter/sbt-missinglink/issues/12.

A dependency can be excluded from the analysis by the module filter. The current implementation is pretty similar to the maven style.

SBT:
```
missinglinkExcludedDependencies += moduleFilter(organization = "com.google.guava")
missinglinkExcludedDependencies += moduleFilter(organization = "ch.qos.logback", name = "logback-core")
```

Maven:
```xml
<excludeDependencies>
  <excludeDependency>
    <groupId>ch.qos.logback</groupId>
    <artifactId>logback-core</artifactId>
  </excludeDependency>
  <excludeDependency>
    <groupId>ch.qos.logback</groupId>
    <artifactId>logback-classic</artifactId>
  </excludeDependency>
</excludeDependency>
```