### PR TITLE
Ignore conflicts in certain packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ You can test another configuration, such as `Test` or `Runtime`, with:
 > theProject/Runtime/missinglinkCheck
 ```
 
+### Do not fail on conflicts
+
+By default, the plugin fails the build if any conflicts are found. 
+It can be disabled by the `missinglinkFailOnConflicts` setting:
+
+```
+missinglinkFailOnConflicts := false
+```
+
 ### Ignore conflicts in certain packages
 
 Conflicts can be ignored based on the package name of the class that has the conflict. 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,25 @@ You can test another configuration, such as `Test` or `Runtime`, with:
 > theProject/Runtime/missinglinkCheck
 ```
 
+### Ignore conflicts in certain packages
+
+Conflicts can be ignored based on the package name of the class that has the conflict. 
+There are separate configuration options for ignoring conflicts on the "source" side of the conflict and the "destination" side of the conflict.
+Packages on the source side can be ignored with `missinglinkIgnoreSourcePackages` and packages on the destination side can be ignored with `missinglinkIgnoreDestinationPackages`:
+
+```
+missinglinkIgnoreDestinationPackages += IgnoredPackage("com.google.common")
+missinglinkIgnoreSourcePackages += IgnoredPackage("com.example")
+```
+
+By default, all subpackages of the specified package are also ignored, but this can be disabled by the `ignoreSubpackages` field: `IgnoredPackage("test", ignoreSubpackages = false)`.
+
 ### Unsupported features
 
 At the moment, compared to the upstream `missinglink` project, this sbt plugin
 does not support the following features:
 
 * Excluding some dependencies from the analysis
-* Ignoring conflicts in certain packages
 
 ## More information
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val `sbt-missinglink` = project
   .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.spotify" % "missinglink-core" % "0.2.0"
+      "com.spotify" % "missinglink-core" % "0.2.1"
     ),
     // configuration fro scripted
     scriptedLaunchOpts := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "com.spotify" % "missinglink-core" % "0.2.0"
+  "com.spotify" % "missinglink-core" % "0.2.1"
 )
 
 unmanagedSourceDirectories in Compile +=

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -21,11 +21,10 @@ import com.spotify.missinglink.datamodel.{
 
 object MissingLinkPlugin extends AutoPlugin {
 
-  trait Types {
-    final case class IgnoredPackage(name: String, ignoreSubpackages: Boolean = true)
-  }
+  object autoImport {
 
-  object autoImport extends Types {
+    final case class IgnoredPackage(name: String, ignoreSubpackages: Boolean = true)
+
     val missinglinkCheck: TaskKey[Unit] =
       taskKey[Unit]("Run the missinglink checks")
 
@@ -34,13 +33,13 @@ object MissingLinkPlugin extends AutoPlugin {
 
     val missinglinkIgnoreSourcePackages: SettingKey[Seq[IgnoredPackage]] =
       settingKey[Seq[IgnoredPackage]](
-        "Optional list of packages to ignore conflicts in where the source of the conflict " +
+        "Optional list of packages to ignore conflicts where the source of the conflict " +
           "is in one of the specified packages."
       )
 
     val missinglinkIgnoreDestinationPackages: SettingKey[Seq[IgnoredPackage]] =
       settingKey[Seq[IgnoredPackage]](
-        "Optional list of packages to ignore conflicts in where the destination/called-side " +
+        "Optional list of packages to ignore conflicts where the destination/called-side " +
           "of the conflict is in one of the specified packages."
       )
   }
@@ -73,12 +72,12 @@ object MissingLinkPlugin extends AutoPlugin {
           ""
         }
 
-        log.warn(s"$filteredTotal conflicts found! $diffMessage")
+        log.info(s"$filteredTotal conflicts found! $diffMessage")
 
         outputConflicts(filteredConflicts, log)
 
         if (failOnConflicts)
-          throw new MessageOnlyException(s"There were ($filteredTotal) conflicts")
+          throw new MessageOnlyException(s"There were $filteredTotal conflicts")
       } else {
         log.info("No conflicts found")
       }
@@ -199,7 +198,7 @@ object MissingLinkPlugin extends AutoPlugin {
       name: String,
       setting: String,
       field: Dependency => ClassTypeDescriptor
-    ): Seq[Conflict] => Seq[Conflict] = input => {
+    ): Seq[Conflict] => Seq[Conflict] = { input =>
 
       if (ignoredPackages.nonEmpty) {
         log.debug(s"Ignoring $name packages: ${ignoredPackages.mkString(", ")}")
@@ -219,7 +218,7 @@ object MissingLinkPlugin extends AutoPlugin {
         val diff = input.length - filtered.length
 
         if (diff != 0) {
-          log.warn(
+          log.info(
             s"""
             |$diff conflicts found in ignored $name packages.
             |Run plugin again without the '$setting' configuration to see all conflicts that were found.

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -199,7 +199,6 @@ object MissingLinkPlugin extends AutoPlugin {
       setting: String,
       field: Dependency => ClassTypeDescriptor
     ): Seq[Conflict] => Seq[Conflict] = { input =>
-
       if (ignoredPackages.nonEmpty) {
         log.debug(s"Ignoring $name packages: ${ignoredPackages.mkString(", ")}")
 

--- a/src/sbt-test/missinglink/do-not-fail-on-conflicts/build.sbt
+++ b/src/sbt-test/missinglink/do-not-fail-on-conflicts/build.sbt
@@ -1,0 +1,18 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `ignore-source-package` = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+      "com.google.guava" % "guava" % "18.0" % Runtime,
+    ),
+
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    missinglinkFailOnConflicts := false
+  )

--- a/src/sbt-test/missinglink/do-not-fail-on-conflicts/build.sbt
+++ b/src/sbt-test/missinglink/do-not-fail-on-conflicts/build.sbt
@@ -3,7 +3,7 @@ inThisBuild(Def.settings(
   scalaVersion := "2.12.8",
 ))
 
-lazy val `ignore-source-package` = project
+lazy val `do-not-fail-on-conflicts` = project
   .in(file("."))
   .settings(
     libraryDependencies ++= Seq(

--- a/src/sbt-test/missinglink/do-not-fail-on-conflicts/project/plugins.sbt
+++ b/src/sbt-test/missinglink/do-not-fail-on-conflicts/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/do-not-fail-on-conflicts/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/do-not-fail-on-conflicts/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/do-not-fail-on-conflicts/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/do-not-fail-on-conflicts/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/do-not-fail-on-conflicts/test
+++ b/src/sbt-test/missinglink/do-not-fail-on-conflicts/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> runtime:missinglinkCheck

--- a/src/sbt-test/missinglink/ignore-destination-package/build.sbt
+++ b/src/sbt-test/missinglink/ignore-destination-package/build.sbt
@@ -1,0 +1,18 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `ignore-destination-package` = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+      "com.google.guava" % "guava" % "18.0" % Runtime,
+    ),
+
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    missinglinkIgnoreDestinationPackages += IgnoredPackage("com.google.common")
+  )

--- a/src/sbt-test/missinglink/ignore-destination-package/project/plugins.sbt
+++ b/src/sbt-test/missinglink/ignore-destination-package/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/ignore-destination-package/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/ignore-destination-package/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/ignore-destination-package/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/ignore-destination-package/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/ignore-destination-package/test
+++ b/src/sbt-test/missinglink/ignore-destination-package/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> runtime:missinglinkCheck

--- a/src/sbt-test/missinglink/ignore-source-package/build.sbt
+++ b/src/sbt-test/missinglink/ignore-source-package/build.sbt
@@ -1,0 +1,18 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `ignore-source-package` = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+      "com.google.guava" % "guava" % "18.0" % Runtime,
+    ),
+
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    missinglinkIgnoreSourcePackages += IgnoredPackage("test")
+  )

--- a/src/sbt-test/missinglink/ignore-source-package/project/plugins.sbt
+++ b/src/sbt-test/missinglink/ignore-source-package/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/ignore-source-package/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/ignore-source-package/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/ignore-source-package/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/ignore-source-package/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/ignore-source-package/test
+++ b/src/sbt-test/missinglink/ignore-source-package/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> runtime:missinglinkCheck


### PR DESCRIPTION
This PR partially covers https://github.com/scalacenter/sbt-missinglink/issues/12.

Conflicts can be ignored based on the package name of the class that has the conflict.
Basically, this is just a backport from the maven plugin.

SBT:
```scala
missinglinkIgnoreDestinationPackages += IgnoredPackage("com.google.common", ignoreSubpackages = false)
missinglinkIgnoreSourcePackages += IgnoredPackage("com.example")
```

Maven:
```xml
<configuration>
  <!-- ignore conflicts with groovy.lang on the caller side -->
  <ignoreSourcePackages>
    <ignoreSourcePackages>
      <package>com.example</package>
    </ignoreSourcePackages>
    <ignoreSubpackages>false</ignoreSubpackages>
  </ignoreSourcePackages>
  <!-- ignore conflicts with com.foo on the callee side -->
  <ignoreDestinationPackages>
    <ignoreDestinationPackage>
      <package>com.google.common</package>
    </ignoreDestinationPackage>
  </ignoreDestinationPackages>
</configuration>
```


Also, this PR brings a new setting `missinglinkFailOnConflicts`:

SBT:
```scala
missinglinkFailOnConflicts := false
```

Maven:
```xml
<configuration>
  <failOnConflicts>true</failOnConflicts>
</configuration>
```