### PR TITLE
Fix #26: Prevent concurrent execution of `missinglinkCheck`.

### DIFF
--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -53,49 +53,56 @@ object MissingLinkPlugin extends AutoPlugin {
   override def requires: Plugins = JvmPlugin
   override def trigger: PluginTrigger = allRequirements
 
+  // missinglink-core has non-threadsafe caches
+  val missinglinkConflictsTag = Tags.Tag("missinglinkConflicts")
+
   val configSettings: Seq[Setting[_]] = Def.settings(
-    missinglinkCheck := {
-      val log = streams.value.log
+    missinglinkCheck := Def
+      .task {
+        val log = streams.value.log
 
-      val cp = fullClasspath.value
-      val classDir = (classDirectory in Compile).value
-      val failOnConflicts = missinglinkFailOnConflicts.value
-      val ignoreSourcePackages = missinglinkIgnoreSourcePackages.value
-      val ignoreDestinationPackages = missinglinkIgnoreDestinationPackages.value
-      val filter =
-        missinglinkExcludedDependencies.value.foldLeft[ModuleFilter](_ => true)((k, v) => k - v)
+        val cp = fullClasspath.value
+        val classDir = (classDirectory in Compile).value
+        val failOnConflicts = missinglinkFailOnConflicts.value
+        val ignoreSourcePackages = missinglinkIgnoreSourcePackages.value
+        val ignoreDestinationPackages = missinglinkIgnoreDestinationPackages.value
+        val filter =
+          missinglinkExcludedDependencies.value.foldLeft[ModuleFilter](_ => true)((k, v) => k - v)
 
-      val conflicts = loadArtifactsAndCheckConflicts(cp, classDir, filter, log)
-      val filteredConflicts =
-        filterConflicts(conflicts, ignoreSourcePackages, ignoreDestinationPackages, log)
+        val conflicts = loadArtifactsAndCheckConflicts(cp, classDir, filter, log)
+        val filteredConflicts =
+          filterConflicts(conflicts, ignoreSourcePackages, ignoreDestinationPackages, log)
 
-      if (filteredConflicts.nonEmpty) {
-        val initialTotal = conflicts.length
-        val filteredTotal = filteredConflicts.length
+        if (filteredConflicts.nonEmpty) {
+          val initialTotal = conflicts.length
+          val filteredTotal = filteredConflicts.length
 
-        val diffMessage = if (initialTotal != filteredTotal) {
-          s"($initialTotal conflicts were found before applying filters)"
+          val diffMessage = if (initialTotal != filteredTotal) {
+            s"($initialTotal conflicts were found before applying filters)"
+          } else {
+            ""
+          }
+
+          log.info(s"$filteredTotal conflicts found! $diffMessage")
+
+          outputConflicts(filteredConflicts, log)
+
+          if (failOnConflicts)
+            throw new MessageOnlyException(s"There were $filteredTotal conflicts")
         } else {
-          ""
+          log.info("No conflicts found")
         }
-
-        log.info(s"$filteredTotal conflicts found! $diffMessage")
-
-        outputConflicts(filteredConflicts, log)
-
-        if (failOnConflicts)
-          throw new MessageOnlyException(s"There were $filteredTotal conflicts")
-      } else {
-        log.info("No conflicts found")
       }
-    }
+      .tag(missinglinkConflictsTag)
+      .value,
   )
 
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
     missinglinkFailOnConflicts := true,
     missinglinkIgnoreSourcePackages := Nil,
     missinglinkIgnoreDestinationPackages := Nil,
-    missinglinkExcludedDependencies := Nil
+    missinglinkExcludedDependencies := Nil,
+    concurrentRestrictions += Tags.limit(missinglinkConflictsTag, 1),
   )
 
   override def projectSettings: Seq[Setting[_]] = {


### PR DESCRIPTION
`missinglink-core` is not thread-safe, which can lead to ConcurrentModificationException in case of multiple projects. This commit prevents multiple `missinglinkCheck` tasks to run at the same time.

Revival of #28. Credit for the fix goes to @OlegYch.