### PR TITLE
Update to missing-link 0.2.2: support Multi-Release JARs and concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ missinglinkExcludedDependencies += moduleFilter(organization = "com.google.guava
 missinglinkExcludedDependencies += moduleFilter(organization = "ch.qos.logback", name = "logback-core")
 ```
 
+### Limiting the concurrency
+
+sbt runs the missing-link analysis on the modules you have concurrently.
+Analysis of each module can take up a considerable amount of memory,
+so you might want to limit the degree of concurrency.
+To run missing-link at most on 4 projects at a time, add this setting to your project `root`.
+
+```scala
+concurrentRestrictions += Tags.limit(missinglinkConflictsTag, 4)
+```
+
 ## More information
 
 You can find more information about the problem statement, caveats and

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val `sbt-missinglink` = project
   .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.spotify" % "missinglink-core" % "0.2.1"
+      "com.spotify" % "missinglink-core" % "0.2.2"
     ),
     // configuration fro scripted
     scriptedLaunchOpts := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "com.spotify" % "missinglink-core" % "0.2.1"
+  "com.spotify" % "missinglink-core" % "0.2.2"
 )
 
 unmanagedSourceDirectories in Compile +=

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -53,7 +53,7 @@ object MissingLinkPlugin extends AutoPlugin {
   override def requires: Plugins = JvmPlugin
   override def trigger: PluginTrigger = allRequirements
 
-  // missinglink-core has non-threadsafe caches
+  // Make it easy to throttle the concurrency of running missing-link on multiple projects, it consumes a lot of memory
   val missinglinkConflictsTag = Tags.Tag("missinglinkConflicts")
 
   val configSettings: Seq[Setting[_]] = Def.settings(
@@ -102,7 +102,6 @@ object MissingLinkPlugin extends AutoPlugin {
     missinglinkIgnoreSourcePackages := Nil,
     missinglinkIgnoreDestinationPackages := Nil,
     missinglinkExcludedDependencies := Nil,
-    concurrentRestrictions += Tags.limit(missinglinkConflictsTag, 1),
   )
 
   override def projectSettings: Seq[Setting[_]] = {


### PR DESCRIPTION
closes https://github.com/scalacenter/sbt-missinglink/pull/33
