### PR TITLE
Add target filters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val `sbt-missinglink` = project
   .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.spotify" % "missinglink-core" % "0.2.5"
+      "com.spotify" % "missinglink-core" % "0.2.6"
     ),
     // configuration fro scripted
     scriptedLaunchOpts := {

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -6,7 +6,9 @@ import sbt.librarymanagement.ModuleFilter
 import sbt.plugins.JvmPlugin
 
 import java.io.FileInputStream
+
 import scala.collection.JavaConverters._
+
 import com.spotify.missinglink.{ArtifactLoader, Conflict, ConflictChecker, Java9ModuleLoader}
 import com.spotify.missinglink.Conflict.ConflictCategory
 import com.spotify.missinglink.datamodel.{

--- a/src/sbt-test/missinglink/target-destination-package/build.sbt
+++ b/src/sbt-test/missinglink/target-destination-package/build.sbt
@@ -1,0 +1,19 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `target-destination-package` = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+      "com.google.guava" % "guava" % "18.0" % Runtime,
+    ),
+
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    // Will ignore Guava conflict
+    missinglinkTargetDestinationPackages += TargetedPackage("test")
+  )

--- a/src/sbt-test/missinglink/target-destination-package/project/plugins.sbt
+++ b/src/sbt-test/missinglink/target-destination-package/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/target-destination-package/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/target-destination-package/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/target-destination-package/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/target-destination-package/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/target-destination-package/test
+++ b/src/sbt-test/missinglink/target-destination-package/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> runtime:missinglinkCheck

--- a/src/sbt-test/missinglink/target-source-package/build.sbt
+++ b/src/sbt-test/missinglink/target-source-package/build.sbt
@@ -1,0 +1,18 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `target-source-package` = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+      "com.google.guava" % "guava" % "18.0" % Runtime,
+    ),
+
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    missinglinkTargetSourcePackages += TargetedPackage("test")
+  )

--- a/src/sbt-test/missinglink/target-source-package/project/plugins.sbt
+++ b/src/sbt-test/missinglink/target-source-package/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/target-source-package/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/target-source-package/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/target-source-package/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/target-source-package/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/target-source-package/test
+++ b/src/sbt-test/missinglink/target-source-package/test
@@ -1,3 +1,3 @@
 > compile
 > compile:missinglinkCheck
-> runtime:missinglinkCheck
+-> runtime:missinglinkCheck

--- a/src/sbt-test/missinglink/target-source-package/test
+++ b/src/sbt-test/missinglink/target-source-package/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> runtime:missinglinkCheck


### PR DESCRIPTION
Adds support for two new params in the upstream Missinglink library: [targetSourcePackages and targetDestinationPackages](https://github.com/spotify/missinglink/pull/266). These params allow the user to specify package names (unlike the existing ignore* options) which will filter found conflicts down to _only_ those conflicts that match on package/subpackage name.

cc @julienrf as most recent contributor 😃 