### PR TITLE
Add option to also scan all dependencies

### DIFF
--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -8,6 +8,7 @@ import sbt.plugins.JvmPlugin
 import java.io.FileInputStream
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.Map
 
 import com.spotify.missinglink.{ArtifactLoader, Conflict, ConflictChecker, Java9ModuleLoader}
 import com.spotify.missinglink.Conflict.ConflictCategory
@@ -203,10 +204,7 @@ object MissingLinkPlugin extends AutoPlugin {
 
     val projectArtifact =
       if (scanDependencies)
-        new ArtifactBuilder()
-          .name(new ArtifactName("project"))
-          .classes(runtimeArtifactsAfterExclusions.flatMap(_.classes.asScala).toMap.asJava)
-          .build()
+        classesToArtifact(runtimeArtifactsAfterExclusions.flatMap(_.classes.asScala).toMap)
       else
         toArtifact(classDirectory)
 
@@ -242,11 +240,14 @@ object MissingLinkPlugin extends AutoPlugin {
         .map(loadClass)
         .map(c => c.className() -> c)
         .toMap
-        .asJava
 
+    classesToArtifact(classes)
+  }
+
+  private def classesToArtifact(classes: Map[ClassTypeDescriptor, DeclaredClass]): Artifact = {
     new ArtifactBuilder()
       .name(new ArtifactName("project"))
-      .classes(classes)
+      .classes(classes.asJava)
       .build()
   }
 

--- a/src/sbt-test/missinglink/ignores-unused-dependency/build.sbt
+++ b/src/sbt-test/missinglink/ignores-unused-dependency/build.sbt
@@ -1,0 +1,22 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `has-problematic-dependency` = project
+  .in(file("has-problematic-dependency"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+    ),
+    compileOrder := CompileOrder.JavaThenScala,
+  )
+
+lazy val `uses-problematic-dependency` = project
+  .in(file("."))
+  .dependsOn(`has-problematic-dependency`)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "18.0",
+    )
+  )

--- a/src/sbt-test/missinglink/ignores-unused-dependency/has-problematic-dependency/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/ignores-unused-dependency/has-problematic-dependency/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/ignores-unused-dependency/has-problematic-dependency/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/ignores-unused-dependency/has-problematic-dependency/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/ignores-unused-dependency/project/plugins.sbt
+++ b/src/sbt-test/missinglink/ignores-unused-dependency/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/ignores-unused-dependency/test
+++ b/src/sbt-test/missinglink/ignores-unused-dependency/test
@@ -1,0 +1,3 @@
+> compile
+> compile:missinglinkCheck
+> missinglinkCheck

--- a/src/sbt-test/missinglink/scans-dependencies/build.sbt
+++ b/src/sbt-test/missinglink/scans-dependencies/build.sbt
@@ -1,0 +1,23 @@
+inThisBuild(Def.settings(
+  version := "0.1.0",
+  scalaVersion := "2.12.8",
+))
+
+lazy val `has-problematic-dependency` = project
+  .in(file("has-problematic-dependency"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "14.0",
+    ),
+    compileOrder := CompileOrder.JavaThenScala,
+  )
+
+lazy val `uses-problematic-dependency` = project
+  .in(file("."))
+  .dependsOn(`has-problematic-dependency`)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.google.guava" % "guava" % "18.0",
+    ),
+    missinglinkScanDependencies := true
+  )

--- a/src/sbt-test/missinglink/scans-dependencies/has-problematic-dependency/src/main/java/test/Foo.java
+++ b/src/sbt-test/missinglink/scans-dependencies/has-problematic-dependency/src/main/java/test/Foo.java
@@ -1,0 +1,5 @@
+package test;
+
+public enum Foo {
+  BAR
+}

--- a/src/sbt-test/missinglink/scans-dependencies/has-problematic-dependency/src/main/scala/test/ProblematicDependency.scala
+++ b/src/sbt-test/missinglink/scans-dependencies/has-problematic-dependency/src/main/scala/test/ProblematicDependency.scala
@@ -1,0 +1,14 @@
+package test
+
+import com.google.common.base.Enums
+
+/**
+ * Calls a method in the Guava Enums class which was removed in guava 18. If a project calls this
+ * method while overriding Guava to >= 18, it will cause a NoSuchMethodError at runtime.
+ */
+object ProblematicDependency {
+
+  def reliesOnRemovedMethod(): AnyRef = {
+    Enums.valueOfFunction(classOf[Foo])
+  }
+}

--- a/src/sbt-test/missinglink/scans-dependencies/project/plugins.sbt
+++ b/src/sbt-test/missinglink/scans-dependencies/project/plugins.sbt
@@ -1,0 +1,8 @@
+System.getProperty("plugin.version") match {
+  case null =>
+    throw new MessageOnlyException(
+        "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  case pluginVersion =>
+    addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % pluginVersion)
+}

--- a/src/sbt-test/missinglink/scans-dependencies/test
+++ b/src/sbt-test/missinglink/scans-dependencies/test
@@ -1,0 +1,3 @@
+> compile
+-> compile:missinglinkCheck
+-> missinglinkCheck


### PR DESCRIPTION
Salutations! I would like to suggest and implement a feature to optionally scan all dependencies for binary compatibility conflicts, not just code paths that are actually used.

My use case is that I'm maintaining a list of open source project versions that work with each other. Multiple other projects then depend on the versions defined in that list. This ultimately reduces the number of scala-steward PRs that need to be reviewed, while reducing the likelihood of binary compatibility errors.

I would like to introduce this plugin to actually test that there are no binary incompatibilities. However, the plugin currently only supports scanning code paths that are actually used. In order to test the dependencies themselves, I need the plugin to scan _all_ code paths in those dependencies.

---

Background aside, this PR introduces a new setting `missinglinkScanDependencies`, which defaults to `false`. When set to `true`, it causes `missinglink` to scan starting from the full classpath (minus exclusions) instead of the classes in the project being built. This is intended for libraries with many dependencies, to assert that dependent projects can safely use those transitive dependencies themselves without needing to run `missinglink` again.