### PR TITLE
Print a concise conflict summary by default (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,44 @@ missinglinkIgnoreSourcePackages += IgnoredPackage("com.example")
 
 By default, all subpackages of the specified package are also ignored, but this can be disabled by the `ignoreSubpackages` field: `IgnoredPackage("test", ignoreSubpackages = false)`.
 
+### Understanding the conflict report
+
+By default `missinglinkCheck` prints a concise summary, grouping conflicts by *what is missing*
+(the "destination" side) with ready-to-paste ignore snippets:
+
+```
+Missinglink summary: 228 conflicts found.
+
+109 conflicts reference classes missing from the classpath - usually optional dependencies you do not use. Ignore them by the missing package:
+  missinglinkIgnoreDestinationPackages ++= List(
+    IgnoredPackage("jnr.unixsocket"),  // 11 conflicts
+    IgnoredPackage("org.apache.log4j"),  // 84 conflicts
+    IgnoredPackage("org.bouncycastle.jce.provider"),  // 1 conflict
+    IgnoredPackage("org.conscrypt")  // 13 conflicts
+  )
+
+119 conflicts reference methods or fields missing from libraries already on your classpath - usually two dependency versions disagree and a binary-incompatible one was evicted.
+Check `show <proj>/evicted` and align these versions:
+  - org.slf4j:jcl-over-slf4j:2.0.17  (110 conflicts)
+  - javax.activation:javax.activation-api:1.2.0  (9 conflicts)
+To ignore them instead:
+  missinglinkIgnoreDestinationPackages ++= List(
+    IgnoredPackage("javax.activation"),  // 9 conflicts
+    IgnoredPackage("org.apache.commons.logging")  // 110 conflicts
+  )
+
+Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown (which class references each missing symbol, and from which methods).
+```
+
+The two categories get different advice:
+
+- **Missing classes** (`CLASS_NOT_FOUND`): usually an optional dependency you don't ship — ignore the missing destination package.
+- **Missing methods / fields**: usually a real binary incompatibility — realign the named module/version; ignoring can hide a `NoSuchMethodError`.
+
+Suggested packages collapse only by parent/child nesting (`org.bouncycastle.asn1.cms` →
+`org.bouncycastle.asn1`), never across siblings. Set `missinglinkVerbose := true` for the full
+per-class, per-call-site breakdown.
+
 ### Excluding some dependencies from the analysis
 
 You can exclude certain dependencies using `moduleFilter`:

--- a/README.md
+++ b/README.md
@@ -63,39 +63,29 @@ By default, all subpackages of the specified package are also ignored, but this 
 
 ### Understanding the conflict report
 
-By default `missinglinkCheck` prints a concise summary: conflict counts split by category, each
-with a ready-to-paste snippet to silence it:
+By default `missinglinkCheck` reports the total conflict count, then a concise summary: how many
+dependencies are involved, a per-category breakdown of the conflicts, and a single ready-to-paste
+snippet that excludes the dependencies whose code triggers them:
 
 ```
-Missinglink summary: 206 conflicts found.
-
-87 conflicts reference classes missing from the classpath - usually optional dependencies you do not use. Exclude the dependencies that reference them:
-  <proj>/missinglinkExcludedDependencies ++= List(
-    moduleFilter(organization = "io.netty", name = "netty-common"),  // 84 conflicts
-    moduleFilter(organization = "io.opentelemetry", name = "opentelemetry-sdk-trace")  // 3 conflicts
-  )
-
-119 conflicts reference methods or fields missing from libraries already on your classpath - usually two dependency versions disagree and a binary-incompatible one was evicted.
-Check `show <proj>/evicted` and align these versions:
-  - org.slf4j:jcl-over-slf4j:2.0.17  (110 conflicts)
-  - javax.activation:javax.activation-api:1.2.0  (9 conflicts)
-To ignore them instead:
-  <proj>/missinglinkIgnoreDestinationPackages ++= List(
-    IgnoredPackage("org.apache.commons.logging"),  // 110 conflicts
-    IgnoredPackage("javax.activation")  // 9 conflicts
-  )
-
+206 conflicts found!
+Missinglink summary: conflicts found in 4 dependencies.
+ * 87 conflicts reference classes missing from the classpath
+ * 119 conflicts reference members missing from classes already on your classpath
+Exclude the dependencies that reference them:
+    <proj>/missinglinkExcludedDependencies ++= List(
+      moduleFilter(organization = "io.netty", name = "netty-common"),  // 84 missing classes, 0 missing members
+      moduleFilter(organization = "io.opentelemetry", name = "opentelemetry-sdk-trace"),  // 3 missing classes, 0 missing members
+      moduleFilter(organization = "org.slf4j", name = "jcl-over-slf4j"),  // 0 missing classes, 110 missing members
+      moduleFilter(organization = "javax.activation", name = "javax.activation-api")  // 0 missing classes, 9 missing members
+    )
 Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown (which class references each missing symbol, and from which methods).
 ```
 
-The two categories get different advice:
-
-- **Missing classes** (`CLASS_NOT_FOUND`): usually an optional dependency you don't ship — exclude
-  the dependency that references the missing classes with `missinglinkExcludedDependencies`.
-- **Missing methods / fields**: usually a real binary incompatibility — realign the named
-  module/version. The class is already on the classpath (often in more than one jar), so excluding a
-  dependency won't make it go away; ignore the destination package with
-  `missinglinkIgnoreDestinationPackages` only if you can't realign.
+Conflicts are either a missing class (`CLASS_NOT_FOUND`) or a missing member on a class that *is*
+present: a method (`METHOD_SIGNATURE_NOT_FOUND`) or a field (`FIELD_NOT_FOUND`). Each conflict is
+attributed to the JAR whose bytecode makes the reference, and the per-line comment splits that JAR's
+count into missing classes vs. members (methods and fields).
 
 Set `missinglinkVerbose := true` for the full per-class, per-call-site breakdown.
 

--- a/README.md
+++ b/README.md
@@ -63,18 +63,16 @@ By default, all subpackages of the specified package are also ignored, but this 
 
 ### Understanding the conflict report
 
-By default `missinglinkCheck` prints a concise summary, grouping conflicts by *what is missing*
-(the "destination" side) with ready-to-paste ignore snippets:
+By default `missinglinkCheck` prints a concise summary: conflict counts split by category, each
+with a ready-to-paste snippet to silence it:
 
 ```
-Missinglink summary: 228 conflicts found.
+Missinglink summary: 206 conflicts found.
 
-109 conflicts reference classes missing from the classpath - usually optional dependencies you do not use. Ignore them by the missing package:
-  missinglinkIgnoreDestinationPackages ++= List(
-    IgnoredPackage("jnr.unixsocket"),  // 11 conflicts
-    IgnoredPackage("org.apache.log4j"),  // 84 conflicts
-    IgnoredPackage("org.bouncycastle.jce.provider"),  // 1 conflict
-    IgnoredPackage("org.conscrypt")  // 13 conflicts
+87 conflicts reference classes missing from the classpath - usually optional dependencies you do not use. Exclude the dependencies that reference them:
+  <proj>/missinglinkExcludedDependencies ++= List(
+    moduleFilter(organization = "io.netty", name = "netty-common"),  // 84 conflicts
+    moduleFilter(organization = "io.opentelemetry", name = "opentelemetry-sdk-trace")  // 3 conflicts
   )
 
 119 conflicts reference methods or fields missing from libraries already on your classpath - usually two dependency versions disagree and a binary-incompatible one was evicted.
@@ -82,9 +80,9 @@ Check `show <proj>/evicted` and align these versions:
   - org.slf4j:jcl-over-slf4j:2.0.17  (110 conflicts)
   - javax.activation:javax.activation-api:1.2.0  (9 conflicts)
 To ignore them instead:
-  missinglinkIgnoreDestinationPackages ++= List(
-    IgnoredPackage("javax.activation"),  // 9 conflicts
-    IgnoredPackage("org.apache.commons.logging")  // 110 conflicts
+  <proj>/missinglinkIgnoreDestinationPackages ++= List(
+    IgnoredPackage("org.apache.commons.logging"),  // 110 conflicts
+    IgnoredPackage("javax.activation")  // 9 conflicts
   )
 
 Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown (which class references each missing symbol, and from which methods).
@@ -92,12 +90,14 @@ Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown (wh
 
 The two categories get different advice:
 
-- **Missing classes** (`CLASS_NOT_FOUND`): usually an optional dependency you don't ship — ignore the missing destination package.
-- **Missing methods / fields**: usually a real binary incompatibility — realign the named module/version; ignoring can hide a `NoSuchMethodError`.
+- **Missing classes** (`CLASS_NOT_FOUND`): usually an optional dependency you don't ship — exclude
+  the dependency that references the missing classes with `missinglinkExcludedDependencies`.
+- **Missing methods / fields**: usually a real binary incompatibility — realign the named
+  module/version. The class is already on the classpath (often in more than one jar), so excluding a
+  dependency won't make it go away; ignore the destination package with
+  `missinglinkIgnoreDestinationPackages` only if you can't realign.
 
-Suggested packages collapse only by parent/child nesting (`org.bouncycastle.asn1.cms` →
-`org.bouncycastle.asn1`), never across siblings. Set `missinglinkVerbose := true` for the full
-per-class, per-call-site breakdown.
+Set `missinglinkVerbose := true` for the full per-class, per-call-site breakdown.
 
 ### Excluding some dependencies from the analysis
 

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -85,6 +85,12 @@ object MissingLinkPlugin extends AutoPlugin {
 
     val missinglinkExcludedDependencies =
       settingKey[Seq[ModuleFilter]]("Dependencies that are excluded from analysis")
+
+    val missinglinkVerbose: SettingKey[Boolean] =
+      settingKey[Boolean](
+        "Print the full per-class, per-call-site breakdown of every conflict. " +
+          "When false (the default), only the concise summary is printed."
+      )
   }
 
   import autoImport._
@@ -105,6 +111,7 @@ object MissingLinkPlugin extends AutoPlugin {
         val classDir = (Compile / classDirectory).value
         val failOnConflicts = missinglinkFailOnConflicts.value
         val scanDependencies = missinglinkScanDependencies.value
+        val verbose = missinglinkVerbose.value
         assert(
           missinglinkIgnoreSourcePackages.value.isEmpty || missinglinkTargetSourcePackages.value.isEmpty,
           "ignoreSourcePackages and targetSourcePackages cannot be defined in the same project."
@@ -118,7 +125,8 @@ object MissingLinkPlugin extends AutoPlugin {
         val filter =
           missinglinkExcludedDependencies.value.foldLeft[ModuleFilter](_ => true)((k, v) => k - v)
 
-        val conflicts = loadArtifactsAndCheckConflicts(cp, classDir, scanDependencies, filter, log)
+        val (conflicts, sourceModules) =
+          loadArtifactsAndCheckConflicts(cp, classDir, scanDependencies, filter, log)
 
         val conflictFilters = filterConflicts(
           missinglinkIgnoreSourcePackages.value,
@@ -160,7 +168,7 @@ object MissingLinkPlugin extends AutoPlugin {
 
           log.info(s"$filteredTotal conflicts found! $diffMessage")
 
-          outputConflicts(filteredConflicts, log)
+          outputConflicts(filteredConflicts, sourceModules, verbose, log)
 
           if (failOnConflicts)
             throw new MessageOnlyException(s"There were $filteredTotal conflicts")
@@ -180,6 +188,7 @@ object MissingLinkPlugin extends AutoPlugin {
     missinglinkIgnoreDestinationPackages := Nil,
     missinglinkTargetDestinationPackages := Nil,
     missinglinkExcludedDependencies := Nil,
+    missinglinkVerbose := false,
   )
 
   override def projectSettings: Seq[Setting[?]] = {
@@ -196,9 +205,22 @@ object MissingLinkPlugin extends AutoPlugin {
       log: Logger
   )(implicit
       converter: FileConverter
-  ): Seq[Conflict] = {
+  ): (Seq[Conflict], Map[ClassTypeDescriptor, ModuleID]) = {
 
     val runtimeProjectArtifacts = constructArtifacts(cp, log)
+
+    // Map every class to the dependency (JAR / module) that provides it, so a conflict can be
+    // attributed back to the JAR its calling class came from. First occurrence wins.
+    val sourceModules: Map[ClassTypeDescriptor, ModuleID] =
+      runtimeProjectArtifacts.foldLeft(Map.empty[ClassTypeDescriptor, ModuleID]) { (acc, ma) =>
+        ma.module match {
+          case Some(module) =>
+            ma.artifact.classes().keySet().asScala.foldLeft(acc) { (current, className) =>
+              if (current.contains(className)) current else current + (className -> module)
+            }
+          case None => acc
+        }
+      }
 
     // also need to load JDK classes from the bootstrap classpath
     val bootstrapArtifacts = loadBootstrapArtifacts(bootClasspathToUse(log), log)
@@ -237,7 +259,7 @@ object MissingLinkPlugin extends AutoPlugin {
         allArtifacts.asJava
       )
 
-    conflicts.asScala.toSeq
+    (conflicts.asScala.toSeq, sourceModules)
   }
 
   private def toArtifact(outputDirectory: File): Artifact = {
@@ -345,55 +367,168 @@ object MissingLinkPlugin extends AutoPlugin {
     }
   }
 
-  private def outputConflicts(conflicts: Seq[Conflict], log: Logger): Unit = {
+  private def outputConflicts(
+      conflicts: Seq[Conflict],
+      sourceModules: Map[ClassTypeDescriptor, ModuleID],
+      verbose: Boolean,
+      log: Logger
+  ): Unit = {
     def logLine(msg: String): Unit =
       log.error(msg)
+
+    // Agreement for "N conflict(s) reference(s)": the noun takes "s" in the plural, the verb in the singular.
+    def conflictNoun(count: Int): String = if (count == 1) "conflict" else "conflicts"
+    def referenceVerb(count: Int): String = if (count == 1) "references" else "reference"
 
     val descriptions = Map(
       ConflictCategory.CLASS_NOT_FOUND -> "Class being called not found",
       ConflictCategory.METHOD_SIGNATURE_NOT_FOUND -> "Method being called not found",
     )
 
+    def categoryDesc(category: ConflictCategory): String =
+      descriptions.getOrElse(category, category.name().replace('_', ' '))
+
+    def optionalLineNumber(lineNumber: Int): String =
+      if (lineNumber != 0) ":" + lineNumber else ""
+
     // group conflict by category
     val byCategory = conflicts.groupBy(_.category())
 
-    for ((category, conflictsInCategory) <- byCategory) {
-      val desc = descriptions.getOrElse(category, category.name().replace('_', ' '))
-      logLine("")
-      logLine("Category: " + desc)
+    if (verbose) {
+      for ((category, conflictsInCategory) <- byCategory) {
+        logLine("")
+        logLine("Category: " + categoryDesc(category))
 
-      // next group by artifact containing the conflict
-      val byArtifact = conflictsInCategory.groupBy(_.usedBy())
+        // next group by artifact containing the conflict
+        val byArtifact = conflictsInCategory.groupBy(_.usedBy())
 
-      for ((artifactName, conflictsInArtifact) <- byArtifact) {
-        logLine("  In artifact: " + artifactName.name())
+        for ((artifactName, conflictsInArtifact) <- byArtifact) {
+          logLine("  In artifact: " + artifactName.name())
 
-        // next group by class containing the conflict
-        val byClassName = conflictsInArtifact.groupBy(_.dependency().fromClass())
+          // next group by class containing the conflict
+          val byClassName = conflictsInArtifact.groupBy(_.dependency().fromClass())
 
-        for ((classDesc, conflictsInClass) <- byClassName) {
-          logLine("    In class: " + classDesc.toString())
+          for ((classDesc, conflictsInClass) <- byClassName) {
+            logLine("    In class: " + classDesc.toString())
 
-          for (conflict <- conflictsInClass) {
-            def optionalLineNumber(lineNumber: Int): String =
-              if (lineNumber != 0) ":" + lineNumber else ""
+            // collapse all call sites that share the same missing target + reason
+            val byProblem = conflictsInClass.groupBy { conflict =>
+              (conflict.dependency().describe(), conflict.reason(), conflict.existsIn())
+            }
 
-            val dep = conflict.dependency()
-            logLine(
-              "      In method:  " +
-                dep.fromMethod().prettyWithoutReturnType() +
-                optionalLineNumber(dep.fromLineNumber())
-            )
-            logLine("      " + dep.describe())
-            logLine("      Problem: " + conflict.reason())
-            if (conflict.existsIn() != ConflictChecker.UNKNOWN_ARTIFACT_NAME)
-              logLine("      Found in: " + conflict.existsIn().name())
-            // this could be smarter about separating each blob of warnings by method, but for
-            // now just output a bunch of dashes always
-            logLine("      --------")
+            for (((describe, reason, existsIn), groupedConflicts) <- byProblem) {
+              logLine("      " + describe)
+              logLine("      Problem: " + reason)
+              if (existsIn != ConflictChecker.UNKNOWN_ARTIFACT_NAME)
+                logLine("      Found in: " + existsIn.name())
+
+              val callSites = groupedConflicts
+                .map { conflict =>
+                  val dep = conflict.dependency()
+                  dep.fromMethod().prettyWithoutReturnType() +
+                    optionalLineNumber(dep.fromLineNumber())
+                }
+                .distinct
+                .sorted
+
+              logLine("      Referenced from:")
+              for (callSite <- callSites)
+                logLine("        " + callSite)
+              logLine("      --------")
+            }
           }
         }
       }
+    } else {
+      // Concise, destination-oriented summary: conflicts are described by *what is missing* (not by
+      // which of your JARs makes the call), so the headline and the suppression snippets stay on
+      // the same axis. The advice differs by category (see below).
+      val total = conflicts.size
+
+      logLine("")
+      logLine(s"Missinglink summary: $total ${conflictNoun(total)} found.")
+
+      def packageOf(c: ClassTypeDescriptor): String = {
+        val className = c.getClassName
+        val idx = className.lastIndexOf('.')
+        if (idx < 0) "" else className.substring(0, idx)
+      }
+
+      // Collapse missing packages by true parent/child nesting only: each package folds into the
+      // topmost other package that is its ancestor (IgnoredPackage already covers subpackages).
+      // Siblings such as org.apache.log4j and org.apache.commons.logging stay separate, so a
+      // suggested ignore never reaches beyond something that is actually missing.
+      def collapsedPackages(cs: Seq[Conflict]): Seq[(String, Int)] = {
+        val counts =
+          cs.map(c => packageOf(c.dependency().targetClass()))
+            .filter(_.nonEmpty)
+            .groupBy(identity)
+            .map { case (pkg, occurrences) => pkg -> occurrences.size }
+        val present = counts.keySet
+        def topmostAncestor(p: String): String =
+          present.filter(q => p == q || p.startsWith(q + ".")).minBy(_.length)
+        counts.toSeq
+          .groupBy { case (pkg, _) => topmostAncestor(pkg) }
+          .map { case (root, entries) => root -> entries.map(_._2).sum }
+          .toSeq
+      }
+
+      def ignoreDestinationSnippet(packages: Seq[(String, Int)]): Unit =
+        if (packages.nonEmpty) {
+          logLine("  missinglinkIgnoreDestinationPackages ++= List(")
+          packages.sortBy { case (pkg, _) => pkg }.zipWithIndex.foreach {
+            case ((pkg, count), index) =>
+              val comma = if (index == packages.size - 1) "" else ","
+              logLine(s"""    IgnoredPackage("$pkg")$comma  // $count ${conflictNoun(count)}""")
+          }
+          logLine("  )")
+        }
+
+      val (classNotFound, signatureNotFound) =
+        conflicts.partition(_.category() == ConflictCategory.CLASS_NOT_FOUND)
+
+      if (classNotFound.nonEmpty) {
+        logLine("")
+        logLine(
+          s"${classNotFound.size} ${conflictNoun(classNotFound.size)} " +
+            s"${referenceVerb(classNotFound.size)} classes missing " +
+            "from the classpath - usually optional dependencies you do not use. " +
+            "Ignore them by the missing package:"
+        )
+        ignoreDestinationSnippet(collapsedPackages(classNotFound))
+      }
+
+      if (signatureNotFound.nonEmpty) {
+        logLine("")
+        logLine(
+          s"${signatureNotFound.size} ${conflictNoun(signatureNotFound.size)} " +
+            s"${referenceVerb(signatureNotFound.size)} methods " +
+            "or fields missing from libraries already on your classpath - usually two dependency " +
+            "versions disagree and a binary-incompatible one was evicted."
+        )
+        // For these the target class is present, so we can name the exact module (and resolved
+        // version) that is missing the member - that is the artifact to realign.
+        val culprits =
+          signatureNotFound
+            .flatMap(c => sourceModules.get(c.dependency().targetClass()))
+            .groupBy(m => (m.organization, m.name, m.revision))
+            .map { case ((org, name, revision), ms) => s"$org:$name:$revision" -> ms.size }
+            .toSeq
+            .sortBy { case (label, count) => (-count, label) }
+        if (culprits.nonEmpty) {
+          logLine("Check `show <proj>/evicted` and align these versions:")
+          for ((label, count) <- culprits)
+            logLine(s"  - $label  ($count ${conflictNoun(count)})")
+        }
+        logLine("To ignore them instead:")
+        ignoreDestinationSnippet(collapsedPackages(signatureNotFound))
+      }
+
+      logLine("")
+      logLine(
+        "Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown " +
+          "(which class references each missing symbol, and from which methods)."
+      )
     }
   }
 

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -209,8 +209,7 @@ object MissingLinkPlugin extends AutoPlugin {
 
     val runtimeProjectArtifacts = constructArtifacts(cp, log)
 
-    // Map every class to the dependency (JAR / module) that provides it, so a conflict can be
-    // attributed back to the JAR its calling class came from. First occurrence wins.
+    // Map each class to the module that provides it (first wins), to attribute conflicts to a JAR.
     val sourceModules: Map[ClassTypeDescriptor, ModuleID] =
       runtimeProjectArtifacts.foldLeft(Map.empty[ClassTypeDescriptor, ModuleID]) { (acc, ma) =>
         ma.module match {
@@ -440,24 +439,45 @@ object MissingLinkPlugin extends AutoPlugin {
         }
       }
     } else {
-      // Concise, destination-oriented summary: conflicts are described by *what is missing* (not by
-      // which of your JARs makes the call), so the headline and the suppression snippets stay on
-      // the same axis. The advice differs by category (see below).
+      // Per-category counts: exclude calling JARs (missing classes) or realign/ignore (methods/fields).
       val total = conflicts.size
 
       logLine("")
       logLine(s"Missinglink summary: $total ${conflictNoun(total)} found.")
 
+      // Render `<proj>/<setting> ++= List(...)`, one entry per line with its conflict count, highest first.
+      def logSettingList(setting: String, entries: Seq[(String, Int)]): Unit = {
+        val sorted = entries.sortBy { case (entry, count) => (-count, entry) }
+        logLine(s"  <proj>/$setting ++= List(")
+        sorted.zipWithIndex.foreach { case ((entry, count), index) =>
+          val comma = if (index == sorted.size - 1) "" else ","
+          logLine(s"    $entry$comma  // $count ${conflictNoun(count)}")
+        }
+        logLine("  )")
+      }
+
+      // Group conflicts by calling module; project-local callers have no module to exclude.
+      def excludeDependencySnippet(cs: Seq[Conflict]): Unit = {
+        val byModule = cs
+          .flatMap(c => sourceModules.get(c.dependency().fromClass()))
+          .groupBy(m => (m.organization, m.name))
+          .map { case ((org, name), ms) =>
+            s"""moduleFilter(organization = "$org", name = "$name")""" -> ms.size
+          }
+          .toSeq
+        if (byModule.isEmpty)
+          logLine("  (these calls originate in your own project; nothing to exclude)")
+        else
+          logSettingList("missinglinkExcludedDependencies", byModule)
+      }
+
       def packageOf(c: ClassTypeDescriptor): String = {
-        val className = c.getClassName
+        val className = c.getClassName.replace('/', '.')
         val idx = className.lastIndexOf('.')
         if (idx < 0) "" else className.substring(0, idx)
       }
 
-      // Collapse missing packages by true parent/child nesting only: each package folds into the
-      // topmost other package that is its ancestor (IgnoredPackage already covers subpackages).
-      // Siblings such as org.apache.log4j and org.apache.commons.logging stay separate, so a
-      // suggested ignore never reaches beyond something that is actually missing.
+      // Collapse missing packages into the topmost present ancestor (IgnoredPackage covers subpackages).
       def collapsedPackages(cs: Seq[Conflict]): Seq[(String, Int)] = {
         val counts =
           cs.map(c => packageOf(c.dependency().targetClass()))
@@ -473,16 +493,14 @@ object MissingLinkPlugin extends AutoPlugin {
           .toSeq
       }
 
+      // Destination-package ignores filter the conflict list directly, so they reliably suppress
+      // evicted/duplicated classes that dependency exclusion cannot.
       def ignoreDestinationSnippet(packages: Seq[(String, Int)]): Unit =
-        if (packages.nonEmpty) {
-          logLine("  missinglinkIgnoreDestinationPackages ++= List(")
-          packages.sortBy { case (pkg, _) => pkg }.zipWithIndex.foreach {
-            case ((pkg, count), index) =>
-              val comma = if (index == packages.size - 1) "" else ","
-              logLine(s"""    IgnoredPackage("$pkg")$comma  // $count ${conflictNoun(count)}""")
-          }
-          logLine("  )")
-        }
+        if (packages.nonEmpty)
+          logSettingList(
+            "missinglinkIgnoreDestinationPackages",
+            packages.map { case (pkg, count) => s"""IgnoredPackage("$pkg")""" -> count }
+          )
 
       val (classNotFound, signatureNotFound) =
         conflicts.partition(_.category() == ConflictCategory.CLASS_NOT_FOUND)
@@ -493,9 +511,9 @@ object MissingLinkPlugin extends AutoPlugin {
           s"${classNotFound.size} ${conflictNoun(classNotFound.size)} " +
             s"${referenceVerb(classNotFound.size)} classes missing " +
             "from the classpath - usually optional dependencies you do not use. " +
-            "Ignore them by the missing package:"
+            "Exclude the dependencies that reference them:"
         )
-        ignoreDestinationSnippet(collapsedPackages(classNotFound))
+        excludeDependencySnippet(classNotFound)
       }
 
       if (signatureNotFound.nonEmpty) {
@@ -506,8 +524,7 @@ object MissingLinkPlugin extends AutoPlugin {
             "or fields missing from libraries already on your classpath - usually two dependency " +
             "versions disagree and a binary-incompatible one was evicted."
         )
-        // For these the target class is present, so we can name the exact module (and resolved
-        // version) that is missing the member - that is the artifact to realign.
+        // The target class is present, so name the module/version missing the member to realign.
         val culprits =
           signatureNotFound
             .flatMap(c => sourceModules.get(c.dependency().targetClass()))

--- a/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbtmissinglink/MissingLinkPlugin.scala
@@ -160,18 +160,21 @@ object MissingLinkPlugin extends AutoPlugin {
           val initialTotal = conflicts.length
           val filteredTotal = filteredConflicts.length
 
-          val diffMessage = if (initialTotal != filteredTotal) {
-            s"($initialTotal conflicts were found before applying filters)"
-          } else {
-            ""
-          }
+          val diffMessage =
+            if (initialTotal != filteredTotal)
+              s" ($initialTotal conflicts were found before applying filters)"
+            else
+              ""
 
-          log.info(s"$filteredTotal conflicts found! $diffMessage")
+          val conflictNoun = if (filteredTotal == 1) "conflict" else "conflicts"
+          log.info(s"$filteredTotal $conflictNoun found!$diffMessage")
 
           outputConflicts(filteredConflicts, sourceModules, verbose, log)
 
-          if (failOnConflicts)
-            throw new MessageOnlyException(s"There were $filteredTotal conflicts")
+          if (failOnConflicts) {
+            val verb = if (filteredTotal == 1) "was" else "were"
+            throw new MessageOnlyException(s"There $verb $filteredTotal $conflictNoun")
+          }
         } else {
           log.info("No conflicts found")
         }
@@ -375,7 +378,6 @@ object MissingLinkPlugin extends AutoPlugin {
     def logLine(msg: String): Unit =
       log.error(msg)
 
-    // Agreement for "N conflict(s) reference(s)": the noun takes "s" in the plural, the verb in the singular.
     def conflictNoun(count: Int): String = if (count == 1) "conflict" else "conflicts"
     def referenceVerb(count: Int): String = if (count == 1) "references" else "reference"
 
@@ -390,11 +392,27 @@ object MissingLinkPlugin extends AutoPlugin {
     def optionalLineNumber(lineNumber: Int): String =
       if (lineNumber != 0) ":" + lineNumber else ""
 
-    // group conflict by category
-    val byCategory = conflicts.groupBy(_.category())
+    // Attribute every conflict to the JAR that references the missing symbol
+    val byModule: Seq[((String, String), (Int, Int))] =
+      conflicts
+        .flatMap(c => sourceModules.get(c.dependency().fromClass()).map(_ -> c.category()))
+        .groupBy { case (module, _) => (module.organization, module.name) }
+        .map { case (key, grouped) =>
+          val missingClasses = grouped.count(_._2 == ConflictCategory.CLASS_NOT_FOUND)
+          key -> (missingClasses, grouped.size - missingClasses)
+        }
+        .toSeq
+        .sortBy { case ((org, name), (classes, members)) => (-classes, -members, org, name) }
+
+    logLine(
+      if (byModule.isEmpty) "Missinglink summary: conflicts found."
+      else
+        s"Missinglink summary: conflicts found in ${byModule.size} " +
+          s"${if (byModule.size == 1) "dependency" else "dependencies"}."
+    )
 
     if (verbose) {
-      for ((category, conflictsInCategory) <- byCategory) {
+      for ((category, conflictsInCategory) <- conflicts.groupBy(_.category())) {
         logLine("")
         logLine("Category: " + categoryDesc(category))
 
@@ -439,109 +457,46 @@ object MissingLinkPlugin extends AutoPlugin {
         }
       }
     } else {
-      // Per-category counts: exclude calling JARs (missing classes) or realign/ignore (methods/fields).
-      val total = conflicts.size
-
-      logLine("")
-      logLine(s"Missinglink summary: $total ${conflictNoun(total)} found.")
-
-      // Render `<proj>/<setting> ++= List(...)`, one entry per line with its conflict count, highest first.
-      def logSettingList(setting: String, entries: Seq[(String, Int)]): Unit = {
-        val sorted = entries.sortBy { case (entry, count) => (-count, entry) }
-        logLine(s"  <proj>/$setting ++= List(")
-        sorted.zipWithIndex.foreach { case ((entry, count), index) =>
-          val comma = if (index == sorted.size - 1) "" else ","
-          logLine(s"    $entry$comma  // $count ${conflictNoun(count)}")
-        }
-        logLine("  )")
-      }
-
-      // Group conflicts by calling module; project-local callers have no module to exclude.
-      def excludeDependencySnippet(cs: Seq[Conflict]): Unit = {
-        val byModule = cs
-          .flatMap(c => sourceModules.get(c.dependency().fromClass()))
-          .groupBy(m => (m.organization, m.name))
-          .map { case ((org, name), ms) =>
-            s"""moduleFilter(organization = "$org", name = "$name")""" -> ms.size
-          }
-          .toSeq
-        if (byModule.isEmpty)
-          logLine("  (these calls originate in your own project; nothing to exclude)")
-        else
-          logSettingList("missinglinkExcludedDependencies", byModule)
-      }
-
-      def packageOf(c: ClassTypeDescriptor): String = {
-        val className = c.getClassName.replace('/', '.')
-        val idx = className.lastIndexOf('.')
-        if (idx < 0) "" else className.substring(0, idx)
-      }
-
-      // Collapse missing packages into the topmost present ancestor (IgnoredPackage covers subpackages).
-      def collapsedPackages(cs: Seq[Conflict]): Seq[(String, Int)] = {
-        val counts =
-          cs.map(c => packageOf(c.dependency().targetClass()))
-            .filter(_.nonEmpty)
-            .groupBy(identity)
-            .map { case (pkg, occurrences) => pkg -> occurrences.size }
-        val present = counts.keySet
-        def topmostAncestor(p: String): String =
-          present.filter(q => p == q || p.startsWith(q + ".")).minBy(_.length)
-        counts.toSeq
-          .groupBy { case (pkg, _) => topmostAncestor(pkg) }
-          .map { case (root, entries) => root -> entries.map(_._2).sum }
-          .toSeq
-      }
-
-      // Destination-package ignores filter the conflict list directly, so they reliably suppress
-      // evicted/duplicated classes that dependency exclusion cannot.
-      def ignoreDestinationSnippet(packages: Seq[(String, Int)]): Unit =
-        if (packages.nonEmpty)
-          logSettingList(
-            "missinglinkIgnoreDestinationPackages",
-            packages.map { case (pkg, count) => s"""IgnoredPackage("$pkg")""" -> count }
-          )
-
       val (classNotFound, signatureNotFound) =
         conflicts.partition(_.category() == ConflictCategory.CLASS_NOT_FOUND)
 
-      if (classNotFound.nonEmpty) {
-        logLine("")
-        logLine(
-          s"${classNotFound.size} ${conflictNoun(classNotFound.size)} " +
-            s"${referenceVerb(classNotFound.size)} classes missing " +
-            "from the classpath - usually optional dependencies you do not use. " +
-            "Exclude the dependencies that reference them:"
-        )
-        excludeDependencySnippet(classNotFound)
-      }
+      def classCount(n: Int): String = s"$n missing ${if (n == 1) "class" else "classes"}"
+      def memberCount(n: Int): String = s"$n missing ${if (n == 1) "member" else "members"}"
 
-      if (signatureNotFound.nonEmpty) {
-        logLine("")
+      if (classNotFound.nonEmpty)
         logLine(
-          s"${signatureNotFound.size} ${conflictNoun(signatureNotFound.size)} " +
-            s"${referenceVerb(signatureNotFound.size)} methods " +
-            "or fields missing from libraries already on your classpath - usually two dependency " +
-            "versions disagree and a binary-incompatible one was evicted."
+          s" * ${classNotFound.size} ${conflictNoun(classNotFound.size)} " +
+            s"${referenceVerb(classNotFound.size)} classes missing from the classpath"
         )
-        // The target class is present, so name the module/version missing the member to realign.
-        val culprits =
-          signatureNotFound
-            .flatMap(c => sourceModules.get(c.dependency().targetClass()))
-            .groupBy(m => (m.organization, m.name, m.revision))
-            .map { case ((org, name, revision), ms) => s"$org:$name:$revision" -> ms.size }
-            .toSeq
-            .sortBy { case (label, count) => (-count, label) }
-        if (culprits.nonEmpty) {
-          logLine("Check `show <proj>/evicted` and align these versions:")
-          for ((label, count) <- culprits)
-            logLine(s"  - $label  ($count ${conflictNoun(count)})")
+      if (signatureNotFound.nonEmpty)
+        logLine(
+          s" * ${signatureNotFound.size} ${conflictNoun(signatureNotFound.size)} " +
+            s"${referenceVerb(signatureNotFound.size)} members missing from classes already on your classpath"
+        )
+
+      if (byModule.nonEmpty) {
+        logLine("Exclude the dependencies that reference them:")
+        logLine("    <proj>/missinglinkExcludedDependencies ++= List(")
+        byModule.zipWithIndex.foreach { case (((org, name), (classes, members)), index) =>
+          val comma = if (index == byModule.size - 1) "" else ","
+          logLine(
+            s"""      moduleFilter(organization = "$org", name = "$name")$comma""" +
+              s"  // ${classCount(classes)}, ${memberCount(members)}"
+          )
         }
-        logLine("To ignore them instead:")
-        ignoreDestinationSnippet(collapsedPackages(signatureNotFound))
+        logLine("    )")
       }
 
-      logLine("")
+      val projectLocal =
+        conflicts.count(c => !sourceModules.contains(c.dependency().fromClass()))
+      if (projectLocal != 0) {
+        val verb = if (projectLocal == 1) "originates" else "originate"
+        logLine(
+          s"$projectLocal ${conflictNoun(projectLocal)} $verb in your own project and cannot " +
+            "be excluded this way."
+        )
+      }
+
       logLine(
         "Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown " +
           "(which class references each missing symbol, and from which methods)."


### PR DESCRIPTION
Attempt to address the verbose output issue #21. `missinglinkCheck` now prints a concise summary by default instead of the full per-call-site list:
- conflict counts split by category (missing classes vs missing methods/fields)
- missing classes: copy-paste missinglinkExcludedDependencies snippets keyed by JAR coordinates
- missing methods/fields: the misaligned modules/versions to realign, plus copy-paste missinglinkIgnoreDestinationPackages ignore snippets to silence them instead
- full breakdown still available with missinglinkVerbose := true

Output example:
```
Missinglink summary: 206 conflicts found.

87 conflicts reference classes missing from the classpath - usually optional dependencies you do not use. Exclude the dependencies that reference them:
  <proj>/missinglinkExcludedDependencies ++= List(
    moduleFilter(organization = "io.netty", name = "netty-common"),  // 84 conflicts
    moduleFilter(organization = "io.opentelemetry", name = "opentelemetry-sdk-trace")  // 3 conflicts
  )

119 conflicts reference methods or fields missing from libraries already on your classpath - usually two dependency versions disagree and a binary-incompatible one was evicted.
Check `show <proj>/evicted` and align these versions:
  - org.slf4j:jcl-over-slf4j:2.0.17  (110 conflicts)
  - javax.activation:javax.activation-api:1.2.0  (9 conflicts)
To ignore them instead:
  <proj>/missinglinkIgnoreDestinationPackages ++= List(
    IgnoredPackage("org.apache.commons.logging"),  // 110 conflicts
    IgnoredPackage("javax.activation")  // 9 conflicts
  )

Re-run with 'missinglinkVerbose := true' to see the full per-class breakdown (which class references each missing symbol, and from which methods).
```